### PR TITLE
Novena support

### DIFF
--- a/Transceiver52M/UHDDevice.cpp
+++ b/Transceiver52M/UHDDevice.cpp
@@ -824,7 +824,7 @@ bool uhd_device::restart()
 	cmd.stream_now = false;
 	cmd.time_spec = uhd::time_spec_t(current.get_real_secs() + delay);
 
-	usrp_dev->issue_stream_cmd(cmd);
+	rx_stream->issue_stream_cmd(cmd);
 
 	return flush_recv(10);
 }
@@ -865,7 +865,7 @@ bool uhd_device::stop()
 	uhd::stream_cmd_t stream_cmd =
 		uhd::stream_cmd_t::STREAM_MODE_STOP_CONTINUOUS;
 
-	usrp_dev->issue_stream_cmd(stream_cmd);
+	rx_stream->issue_stream_cmd(stream_cmd);
 
 	async_event_thrd->cancel();
 	async_event_thrd->join();

--- a/Transceiver52M/UHDDevice.cpp
+++ b/Transceiver52M/UHDDevice.cpp
@@ -48,6 +48,8 @@
  */
 #define UHD_RESTART_TIMEOUT     1.0
 
+#define UMTRX_VGA1_DEF   -18
+
 enum uhd_dev_type {
 	USRP1,
 	USRP2,
@@ -455,9 +457,23 @@ void uhd_device::init_gains()
 {
 	uhd::gain_range_t range;
 
-	range = usrp_dev->get_tx_gain_range();
-	tx_gain_min = range.start();
-	tx_gain_max = range.stop();
+	if (dev_type == UMTRX) {
+		std::vector<std::string> gain_stages = usrp_dev->get_tx_gain_names(0);
+		if (gain_stages[0] == "VGA") {
+			LOG(WARNING) << "Update your UHD version for a proper Tx gain support";
+			range = usrp_dev->get_tx_gain_range();
+			tx_gain_min = range.start();
+			tx_gain_max = range.stop();
+		} else {
+			range = usrp_dev->get_tx_gain_range("VGA2");
+			tx_gain_min = UMTRX_VGA1_DEF + range.start();
+			tx_gain_max = UMTRX_VGA1_DEF + range.stop();
+		}
+	} else {
+		range = usrp_dev->get_tx_gain_range();
+		tx_gain_min = range.start();
+		tx_gain_max = range.stop();
+	}
 
 	range = usrp_dev->get_rx_gain_range();
 	rx_gain_min = range.start();
@@ -548,8 +564,26 @@ double uhd_device::setTxGain(double db, size_t chan)
 		return 0.0f;
 	}
 
-	usrp_dev->set_tx_gain(db, chan);
-	tx_gains[chan] = usrp_dev->get_tx_gain(chan);
+	if (dev_type == UMTRX) {
+		std::vector<std::string> gain_stages = usrp_dev->get_tx_gain_names(0);
+		if (gain_stages[0] == "VGA") {
+			LOG(WARNING) << "Update your UHD version for a proper Tx gain support";
+			usrp_dev->set_tx_gain(db, chan);
+			tx_gains[chan] = usrp_dev->get_tx_gain(chan);
+		} else {
+			// New UHD versions support split configuration of
+			// Tx gain stages. We utilize this to set the gain
+			// configuration, optimal for the Tx signal quality.
+			// From our measurements, VGA1 must be 18dB plus-minus
+			// one and VGA2 is the best when 23dB or lower.
+			usrp_dev->set_tx_gain(UMTRX_VGA1_DEF, "VGA1", chan);
+			usrp_dev->set_tx_gain(db-UMTRX_VGA1_DEF, "VGA2", chan);
+			tx_gains[chan] = usrp_dev->get_tx_gain(chan);
+		}
+	} else {
+		usrp_dev->set_tx_gain(db, chan);
+		tx_gains[chan] = usrp_dev->get_tx_gain(chan);
+	}
 
 	LOG(INFO) << "Set TX gain to " << tx_gains[chan] << "dB";
 

--- a/Transceiver52M/UHDDevice.cpp
+++ b/Transceiver52M/UHDDevice.cpp
@@ -1199,7 +1199,7 @@ bool uhd_device::recv_async_msg()
 	uhd::async_metadata_t md;
 
 	thread_enable_cancel(false);
-	bool rc = usrp_dev->get_device()->recv_async_msg(md);
+	bool rc = tx_stream->recv_async_msg(md);
 	thread_enable_cancel(true);
 	if (!rc)
 		return false;

--- a/Transceiver52M/UHDDevice.cpp
+++ b/Transceiver52M/UHDDevice.cpp
@@ -419,6 +419,7 @@ void uhd_msg_handler(uhd::msg::type_t type, const std::string &msg)
 		LOG(ERR) << msg;
 		break;
 	case uhd::msg::fastpath:
+		std::cerr << msg << std::flush;
 		break;
 	}
 }

--- a/Transceiver52M/UHDDevice.cpp
+++ b/Transceiver52M/UHDDevice.cpp
@@ -36,6 +36,7 @@
 #define E1XX_CLK_RT      52e6
 #define B100_BASE_RT     400000
 #define USRP2_BASE_RT    390625
+#define NOVENA_BASE_RT   480000
 #define TX_AMPL          0.3
 #define SAMPLE_BUF_SZ    (1 << 20)
 
@@ -57,6 +58,7 @@ enum uhd_dev_type {
 	E3XX,
 	X3XX,
 	UMTRX,
+	NOVENA,
 	NUM_USRP_TYPES,
 };
 
@@ -96,6 +98,8 @@ static struct uhd_dev_offset uhd_offsets[NUM_USRP_TYPES * 2] = {
 	{ X3XX,  4, 1.1264e-4, "X3XX 4 SPS"},
 	{ UMTRX, 1, 9.9692e-5, "UmTRX 1 SPS" },
 	{ UMTRX, 4, 7.3846e-5, "UmTRX 4 SPS" },
+	{ NOVENA, 1, 145.801000e-6, "Novena 1 SPS" }, //measured rtt delay @ GSM rate
+	{ NOVENA, 4, 38.541000e-6 + 4.430769230769231e-05, "Novena 4 SPS" }, //measured rtt delay @ GSM rate*4 + internal filter delay
 };
 
 /*
@@ -183,6 +187,8 @@ static double select_rate(uhd_dev_type type, int sps, bool diversity = false)
 	case E3XX:
 	case UMTRX:
 		return GSMRATE * sps;
+	case NOVENA:
+		return NOVENA_BASE_RT * sps;
 	default:
 		break;
 	}
@@ -585,7 +591,7 @@ bool uhd_device::parse_dev_type()
 	std::string mboard_str, dev_str;
 	uhd::property_tree::sptr prop_tree;
 	size_t usrp1_str, usrp2_str, e100_str, e110_str, e310_str,
-	       b100_str, b200_str, b210_str, x300_str, x310_str, umtrx_str;
+	       b100_str, b200_str, b210_str, x300_str, x310_str, umtrx_str, novena_str;
 
 	prop_tree = usrp_dev->get_device()->get_tree();
 	dev_str = prop_tree->access<std::string>("/name").get();
@@ -602,6 +608,7 @@ bool uhd_device::parse_dev_type()
 	x300_str = mboard_str.find("X300");
 	x310_str = mboard_str.find("X310");
 	umtrx_str = dev_str.find("UmTRX");
+	novena_str = dev_str.find("NOVENA");
 
 	if (usrp1_str != std::string::npos) {
 		LOG(ALERT) << "USRP1 is not supported using the UHD driver";
@@ -640,6 +647,9 @@ bool uhd_device::parse_dev_type()
 	} else if (umtrx_str != std::string::npos) {
 		tx_window = TX_WINDOW_FIXED;
 		dev_type = UMTRX;
+	} else if (novena_str != std::string::npos) {
+		tx_window = TX_WINDOW_FIXED;
+		dev_type = NOVENA;
 	} else {
 		LOG(ALERT) << "Unknown UHD device type " << dev_str;
 		return false;
@@ -753,6 +763,8 @@ int uhd_device::open(const std::string &args, bool extref)
 	case USRP2:
 	case X3XX:
 		return RESAMP_100M;
+	case NOVENA:
+		return RESAMP_30_72M;
 	case B200:
 	case B210:
 	case E1XX:

--- a/Transceiver52M/UHDDevice.cpp
+++ b/Transceiver52M/UHDDevice.cpp
@@ -457,7 +457,7 @@ void uhd_device::init_gains()
 {
 	uhd::gain_range_t range;
 
-	if (dev_type == UMTRX) {
+	if (dev_type == UMTRX or dev_type == NOVENA) {
 		std::vector<std::string> gain_stages = usrp_dev->get_tx_gain_names(0);
 		if (gain_stages[0] == "VGA") {
 			LOG(WARNING) << "Update your UHD version for a proper Tx gain support";
@@ -564,7 +564,7 @@ double uhd_device::setTxGain(double db, size_t chan)
 		return 0.0f;
 	}
 
-	if (dev_type == UMTRX) {
+	if (dev_type == UMTRX or dev_type == NOVENA) {
 		std::vector<std::string> gain_stages = usrp_dev->get_tx_gain_names(0);
 		if (gain_stages[0] == "VGA") {
 			LOG(WARNING) << "Update your UHD version for a proper Tx gain support";

--- a/Transceiver52M/osmo-trx.cpp
+++ b/Transceiver52M/osmo-trx.cpp
@@ -203,6 +203,7 @@ RadioInterface *makeRadioInterface(struct trx_config *config,
 		break;
 	case RadioDevice::RESAMP_64M:
 	case RadioDevice::RESAMP_100M:
+	case RadioDevice::RESAMP_30_72M:
 		radio = new RadioInterfaceResamp(usrp,
 						 config->sps, config->chans);
 		break;

--- a/Transceiver52M/radioDevice.h
+++ b/Transceiver52M/radioDevice.h
@@ -35,7 +35,7 @@ class RadioDevice {
   enum TxWindowType { TX_WINDOW_USRP1, TX_WINDOW_FIXED };
 
   /* Radio interface types */
-  enum RadioInterfaceType { NORMAL, RESAMP_64M, RESAMP_100M, DIVERSITY };
+  enum RadioInterfaceType { NORMAL, RESAMP_64M, RESAMP_100M, RESAMP_30_72M, DIVERSITY };
 
   static RadioDevice *make(size_t sps, size_t chans = 1,
                            bool diversity = false, double offset = 0.0);

--- a/Transceiver52M/radioInterfaceResamp.cpp
+++ b/Transceiver52M/radioInterfaceResamp.cpp
@@ -36,6 +36,9 @@ extern "C" {
 #define RESAMP_100M_INRATE			52
 #define RESAMP_100M_OUTRATE			75
 
+#define RESAMP_30_72M_INRATE			325
+#define RESAMP_30_72M_OUTRATE			576
+
 /* Universal resampling parameters */
 #define NUMCHUNKS				24
 
@@ -121,6 +124,10 @@ bool RadioInterfaceResamp::init(int type)
 	case RadioDevice::RESAMP_100M:
 		resamp_inrate = RESAMP_100M_INRATE;
 		resamp_outrate = RESAMP_100M_OUTRATE;
+		break;
+	case RadioDevice::RESAMP_30_72M:
+		resamp_inrate = RESAMP_30_72M_INRATE;
+		resamp_outrate = RESAMP_30_72M_OUTRATE;
 		break;
 	case RadioDevice::NORMAL:
 	default:

--- a/Transceiver52M/radioInterfaceResamp.cpp
+++ b/Transceiver52M/radioInterfaceResamp.cpp
@@ -36,8 +36,9 @@ extern "C" {
 #define RESAMP_100M_INRATE			52
 #define RESAMP_100M_OUTRATE			75
 
-#define RESAMP_30_72M_INRATE			325
-#define RESAMP_30_72M_OUTRATE			576
+/* Resample 30.72 with 4.65549348231 Hz error */
+#define RESAMP_30_72M_INRATE			101
+#define RESAMP_30_72M_OUTRATE			179
 
 /* Universal resampling parameters */
 #define NUMCHUNKS				24


### PR DESCRIPTION
Merge novena-rf support with tree supporting Soapy devices to bring the necessary resampling rates in preparation for supporting novena-rf with the native Soapy device driver.